### PR TITLE
Enable installation into lapis namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# lapis.caching
-Caching extension for LAPIS simulator

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,14 @@
+=============
+lapis.caching
+=============
+
+Caching extension for LAPIS simulator
+
+Installation
+============
+
+Since the tooling support for namespace packages is incomplete,
+`lapis.caching` works as a namespace package on top of
+the non-namespace package `lapis`.
+This prevents development installations (``pip install -e .``)
+from working properly.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+import setuptools
+
+with open("README.md", "r") as readme:
+    long_description = readme.read()
+
+setuptools.setup(
+    name="lapis.caching",
+    version="0.0.1",
+    author="Eileen Kuehn, Max Fischer",
+    author_email="mainekuehn@gmail.com",
+    description="LAPIS extension to simulate caching",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/MatterMiners/lapis.caching",
+    keywords="caching simulation cobald tardis opportunistic scheduling scheduler",
+    # Even though `lapis` is not a namespace package, declaring `lapis.caching`
+    # as one allows to drop `.caching` into `.lapis`. The result works as one.
+    packages=setuptools.find_namespace_packages(include=['lapis.*']),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Development Status :: 2 - Pre-Alpha",
+    ],
+    install_requires=['lapis-sim'],
+    python_requires='>=3.6',
+)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as readme:
+with open("README.rst", "r") as readme:
     long_description = readme.read()
 
 setuptools.setup(
@@ -10,7 +10,6 @@ setuptools.setup(
     author_email="mainekuehn@gmail.com",
     description="LAPIS extension to simulate caching",
     long_description=long_description,
-    long_description_content_type="text/markdown",
     url="https://github.com/MatterMiners/lapis.caching",
     keywords="caching simulation cobald tardis opportunistic scheduling scheduler",
     # Even though `lapis` is not a namespace package, declaring `lapis.caching`

--- a/setup.py
+++ b/setup.py
@@ -11,15 +11,15 @@ setuptools.setup(
     description="LAPIS extension to simulate caching",
     long_description=long_description,
     url="https://github.com/MatterMiners/lapis.caching",
-    keywords="caching simulation cobald tardis opportunistic scheduling scheduler",
+    keywords="caching simulation opportunistic scheduling scheduler",
     # Even though `lapis` is not a namespace package, declaring `lapis.caching`
     # as one allows to drop `.caching` into `.lapis`. The result works as one.
-    packages=setuptools.find_namespace_packages(include=['lapis.*']),
+    packages=setuptools.find_namespace_packages(include=["lapis.*"]),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Development Status :: 2 - Pre-Alpha",
     ],
-    install_requires=['lapis-sim'],
-    python_requires='>=3.6',
+    install_requires=["lapis-sim"],
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
This PR adds the basic facilities to install `lapis.caching` into `lapis`.

Closes #13.